### PR TITLE
Use arduino/cpp-test-action in Unit Test CI workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,36 +20,19 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      BUILD_PATH: ${{ github.workspace }}/extras/test/build
+      COVERAGE_DATA_PATH: extras/coverage-data/coverage.info
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install valgrind
-        run: sudo apt-get --assume-yes install valgrind
-
-      - name: Run unit tests
-        run: |
-          mkdir "$BUILD_PATH"
-          cd "$BUILD_PATH"
-          cmake ..
-          make
-          # Run tests and check for memory leaks
-          valgrind --leak-check=yes --error-exitcode=1 bin/testNmeaParser
-
-      - name: Install lcov
-        run: sudo apt-get --assume-yes install lcov
-
-      - name: Report code coverage
-        run: |
-          cd "$BUILD_PATH"
-          lcov --directory . --capture --output-file coverage.info
-          lcov --quiet --remove coverage.info '/usr/*' '*/extras/test/*' '*/src/lib/*' --output-file coverage.info
-          lcov --list coverage.info
+      - uses: arduino/cpp-test-action@main
+        with:
+          runtime-path: extras/test/build/bin/testNmeaParser
+          coverage-data-path: ${{ env.COVERAGE_DATA_PATH }}
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1
         with:
-          file: ${{ env.BUILD_PATH }}/coverage.info
+          file: ${{ env.COVERAGE_DATA_PATH }}
           fail_ci_if_error: true


### PR DESCRIPTION
This simplifies the workflow and moves the maintenance of the commands used for the testing procedure to a centralized location.