### PR TITLE
If no valid data has been received yet lon/lat shall be NAN

### DIFF
--- a/extras/test/src/test_ArduinoNmeaParser.cpp
+++ b/extras/test/src/test_ArduinoNmeaParser.cpp
@@ -39,8 +39,9 @@ TEST_CASE("No NMEA message received", "[Parser-01]")
 {
   ArduinoNmeaParser parser(nullptr);
 
-  REQUIRE(parser.longitude()                      == Approx(52.2637009));
-  REQUIRE(parser.latitude()                       == Approx(20.9860468));
+  REQUIRE(parser.error()                          == ArduinoNmeaParser::Error::None);
+  REQUIRE(std::isnan(parser.latitude())           == true);
+  REQUIRE(std::isnan(parser.longitude())          == true);
   REQUIRE(parser.time_utc().hour                  == -1);
   REQUIRE(parser.time_utc().minute                == -1);
   REQUIRE(parser.time_utc().second                == -1);
@@ -62,8 +63,8 @@ TEST_CASE("RMC message after startup, no satellites", "[Parser-02]")
   encode(parser, GPRMC);
 
   REQUIRE(parser.error()                          == ArduinoNmeaParser::Error::None);
-  REQUIRE(parser.latitude()                       == Approx(20.9860468));
-  REQUIRE(parser.longitude()                      == Approx(52.2637009));
+  REQUIRE(std::isnan(parser.latitude())           == true);
+  REQUIRE(std::isnan(parser.longitude())          == true);
   REQUIRE(parser.time_utc().hour                  == -1);
   REQUIRE(parser.time_utc().minute                == -1);
   REQUIRE(parser.time_utc().second                == -1);
@@ -85,8 +86,8 @@ TEST_CASE("RMC message after startup, time fix available", "[Parser-03]")
   encode(parser, GPRMC);
 
   REQUIRE(parser.error()                          == ArduinoNmeaParser::Error::None);
-  REQUIRE(parser.latitude()                       == Approx(20.9860468));
-  REQUIRE(parser.longitude()                      == Approx(52.2637009));
+  REQUIRE(std::isnan(parser.latitude())           == true);
+  REQUIRE(std::isnan(parser.longitude())          == true);
   REQUIRE(parser.time_utc().hour                  == 14);
   REQUIRE(parser.time_utc().minute                == 19);
   REQUIRE(parser.time_utc().second                == 28);

--- a/src/ArduinoNmeaParser.cpp
+++ b/src/ArduinoNmeaParser.cpp
@@ -25,7 +25,7 @@ ArduinoNmeaParser::ArduinoNmeaParser(OnRMCUpdateFunc on_rmc_update)
 : _error{Error::None}
 , _parser_state{ParserState::Synching}
 , _parser_buf{{0}, 0}
-, _rmc{20.9860468, 52.2637009, NAN, NAN, NAN, {-1, -1, -1, -1}, {-1, -1, -1}}
+, _rmc{NAN, NAN, NAN, NAN, NAN, {-1, -1, -1, -1}, {-1, -1, -1}}
 , _on_rmc_update{on_rmc_update}
 {
 


### PR DESCRIPTION
@generationmake The initial coordinates were intended to pay homage to a certain person but I agree with your [comment](https://github.com/107-systems/107-Arduino-NMEA-Parser/pull/10#issuecomment-707682043) that NAN might be a better solution.