### PR TITLE
Fix early parse abort in case of missing RMC sentence entries

### DIFF
--- a/extras/test/src/test_ArduinoNmeaParser.cpp
+++ b/extras/test/src/test_ArduinoNmeaParser.cpp
@@ -137,18 +137,7 @@ TEST_CASE("NMEA message with data corruption (checksum mismatch) received", "[Pa
   REQUIRE(parser.error() == ArduinoNmeaParser::Error::Checksum);
 }
 
-TEST_CASE("Invalid GPRMC message received", "[Parser-06]")
-{
-  ArduinoNmeaParser parser(nullptr);
-
-  std::string const GPRMC = "$GPRMC,052852.105,A,5230.868,Y,01320.958,E,077.0,023.5,080720,000.0,W*6E\r\n";
-
-  REQUIRE(parser.error() == ArduinoNmeaParser::Error::None);
-  encode(parser, GPRMC);
-  REQUIRE(parser.error() == ArduinoNmeaParser::Error::RMC);
-}
-
-TEST_CASE("Multiple NMEA messages received", "[Parser-07]")
+TEST_CASE("Multiple NMEA messages received", "[Parser-06]")
 {
   ArduinoNmeaParser parser(nullptr);
 

--- a/extras/test/src/test_GxRMC.cpp
+++ b/extras/test/src/test_GxRMC.cpp
@@ -146,3 +146,21 @@ TEST_CASE("Extracted status indicates void ('V') position data", "[GxRMC-08]")
 
   REQUIRE(data.is_valid == false);
 }
+
+TEST_CASE("GxRMC message contains only date and time, but no location fix yet ", "[GxRMC-09]")
+{
+  std::string const GPRMC = ("$GPRMC,144602.00,V,,,,,,,011120,,,N*7B\r\n");
+
+  nmea::GxRMC::parse(GPRMC.c_str(), data);
+
+  /* RMC TIME = '144602.00' */
+  REQUIRE(data.time_utc.hour        == 14);
+  REQUIRE(data.time_utc.minute      == 46);
+  REQUIRE(data.time_utc.second      == 02);
+  REQUIRE(data.time_utc.microsecond == 0);
+
+  /* RMC DATE = '011120' */
+  REQUIRE(data.date.day             == 1);
+  REQUIRE(data.date.month           == 11);
+  REQUIRE(data.date.year            == 2020);
+}

--- a/extras/test/src/test_GxRMC.cpp
+++ b/extras/test/src/test_GxRMC.cpp
@@ -33,7 +33,8 @@ SCENARIO("Extracting latitude/longiture from valid GPRMC message", "[GxRMC-01]")
   {
     std::string const GPRMC = "$GPRMC,062101.714,A,5001.869,N,01912.114,E,955535.7,116.2,290520,000.0,W*45\r\n";
 
-    REQUIRE(nmea::GxRMC::parse(GPRMC.c_str(), data) == true);
+    nmea::GxRMC::parse(GPRMC.c_str(), data);
+
     REQUIRE(data.latitude  == Approx(50.03114442));
     REQUIRE(data.longitude == Approx(19.20189679));
   }
@@ -42,7 +43,8 @@ SCENARIO("Extracting latitude/longiture from valid GPRMC message", "[GxRMC-01]")
   {
     std::string const GPRMC = "$GPRMC,122311.239,A,4056.748,N,11212.614,W,,,290620,000.0,W*63\r\n";
 
-    REQUIRE(nmea::GxRMC::parse(GPRMC.c_str(), data) == true);
+    nmea::GxRMC::parse(GPRMC.c_str(), data);
+
     REQUIRE(data.latitude  == Approx(40.9458060446613));
     REQUIRE(data.longitude == Approx(-112.210235595703));
   }
@@ -51,7 +53,8 @@ SCENARIO("Extracting latitude/longiture from valid GPRMC message", "[GxRMC-01]")
   {
     std::string const GPRMC = "$GPRMC,122311.239,A,2727.069,S,05859.190,W,,,290620,000.0,W*76\r\n";
 
-    REQUIRE(nmea::GxRMC::parse(GPRMC.c_str(), data) == true);
+    nmea::GxRMC::parse(GPRMC.c_str(), data);
+
     REQUIRE(data.latitude  == Approx(-27.4511422937699));
     REQUIRE(data.longitude == Approx(-58.986502289772));
   }
@@ -60,7 +63,8 @@ SCENARIO("Extracting latitude/longiture from valid GPRMC message", "[GxRMC-01]")
   {
     std::string const GPRMC = "$GPRMC,122311.239,A,0610.522,S,10649.632,E,,,290620,000.0,W*6D\r\n";
 
-    REQUIRE(nmea::GxRMC::parse(GPRMC.c_str(), data) == true);
+    nmea::GxRMC::parse(GPRMC.c_str(), data);
+
     REQUIRE(data.latitude  == Approx(-6.17536097471491));
     REQUIRE(data.longitude == Approx(106.827192306519));
   }
@@ -86,7 +90,8 @@ TEST_CASE("Extracting speed over ground from valid GPRMC message", "[GxRMC-03]")
 {
   std::string const GPRMC = ("$GPRMC,052856.105,A,5230.874,N,01321.056,E,085.7,206.4,080720,000.0,W*78\r\n");
 
-  REQUIRE(nmea::GxRMC::parse(GPRMC.c_str(), data) == true);
+  nmea::GxRMC::parse(GPRMC.c_str(), data);
+
   /* 85.7 kts ~= 44.088 m/s */
   REQUIRE(data.speed == Approx(44.088f));
 }
@@ -95,7 +100,8 @@ TEST_CASE("Extracting track angle from valid GPRMC message", "[GxRMC-04]")
 {
   std::string const GPRMC = ("$GPRMC,052856.105,A,5230.874,N,01321.056,E,085.7,206.4,080720,000.0,W*78\r\n");
 
-  REQUIRE(nmea::GxRMC::parse(GPRMC.c_str(), data) == true);
+  nmea::GxRMC::parse(GPRMC.c_str(), data);
+
   REQUIRE(data.course == Approx(206.4f));
 }
 
@@ -103,7 +109,8 @@ TEST_CASE("Extracting position time from valid GPRMC message", "[GxRMC-05]")
 {
   std::string const GPRMC = ("$GPRMC,052856.105,A,5230.874,N,01321.056,E,085.7,206.4,080720,000.0,W*78\r\n");
 
-  REQUIRE(nmea::GxRMC::parse(GPRMC.c_str(), data) == true);
+  nmea::GxRMC::parse(GPRMC.c_str(), data);
+
   /* 052856.105 -> 05:28:56.105 -> */
   REQUIRE(data.time_utc.hour        == 5);
   REQUIRE(data.time_utc.minute      == 28);
@@ -115,7 +122,8 @@ TEST_CASE("Extracting date from valid GPRMC message", "[GxRMC-06]")
 {
   std::string const GPRMC = ("$GPRMC,052856.105,A,5230.874,N,01321.056,E,085.7,206.4,080720,000.0,W*78\r\n");
 
-  REQUIRE(nmea::GxRMC::parse(GPRMC.c_str(), data) == true);
+  nmea::GxRMC::parse(GPRMC.c_str(), data);
+
   REQUIRE(data.date.day   == 8);
   REQUIRE(data.date.month == 7);
   REQUIRE(data.date.year  == 2020);
@@ -125,7 +133,8 @@ TEST_CASE("Extracting magnetic variation from valid GPRMC message", "[GxRMC-07]"
 {
   std::string const GPRMC = ("$GPRMC,052856.105,A,5230.874,N,01321.056,E,085.7,206.4,080720,000.0,W*78\r\n");
 
-  REQUIRE(nmea::GxRMC::parse(GPRMC.c_str(), data) == true);
+  nmea::GxRMC::parse(GPRMC.c_str(), data);
+
   REQUIRE(data.magnetic_variation == Approx(0.0));
 }
 
@@ -133,16 +142,7 @@ TEST_CASE("Extracted status indicates void ('V') position data", "[GxRMC-08]")
 {
   std::string const GPRMC = ("$GPRMC,052856.105,V,5230.874,N,01321.056,E,085.7,206.4,080720,000.0,W*78\r\n");
 
-  data.latitude = 1.0f; data.longitude = 2.0f; data.speed = 3.0f; data.course = 4.0f;
-  data.time_utc.hour = -1; data.time_utc.minute = -1; data.time_utc.second = -1; data.time_utc.microsecond = -1;
+  nmea::GxRMC::parse(GPRMC.c_str(), data);
 
-  REQUIRE(nmea::GxRMC::parse(GPRMC.c_str(), data) == true);
-  REQUIRE(data.latitude             == 1.0f);
-  REQUIRE(data.longitude            == 2.0f);
-  REQUIRE(data.speed                == 3.0f);
-  REQUIRE(data.course               == 4.0f);
-  REQUIRE(data.time_utc.hour        == 5);
-  REQUIRE(data.time_utc.minute      == 28);
-  REQUIRE(data.time_utc.second      == 56);
-  REQUIRE(data.time_utc.microsecond == 105);
+  REQUIRE(data.is_valid == false);
 }

--- a/src/ArduinoNmeaParser.cpp
+++ b/src/ArduinoNmeaParser.cpp
@@ -120,10 +120,8 @@ void ArduinoNmeaParser::terminateParserBuffer()
 
 void ArduinoNmeaParser::parseGxRMC()
 {
-  if (!nmea::GxRMC::parse(_parser_buf.buf, _rmc))
-    _error = Error::RMC;
-  else {
-    if (_on_rmc_update)
+  nmea::GxRMC::parse(_parser_buf.buf, _rmc);
+
+  if (_on_rmc_update)
       _on_rmc_update(_rmc);
-  }
 }

--- a/src/ArduinoNmeaParser.h
+++ b/src/ArduinoNmeaParser.h
@@ -45,7 +45,7 @@ public:
   inline const nmea::RmcData rmc() const { return _rmc; }
 
 
-  enum class Error { None, Checksum, RMC };
+  enum class Error { None, Checksum };
 
   inline void  clearerr()       { _error = Error::None; }
   inline Error error   () const { return _error; }

--- a/src/nmea/GxRMC.h
+++ b/src/nmea/GxRMC.h
@@ -32,7 +32,7 @@ class GxRMC
 
 public:
 
-  static bool parse(char const * gprmc, RmcData & data);
+  static void parse(char const * gprmc, RmcData & data);
 
 private:
 
@@ -54,8 +54,7 @@ private:
     MagneticVariation,
     MagneticVariationEastWest,
     Checksum,
-    Done,
-    Error
+    Done
   };
 
   static ParserState handle_MessadeId                (char const * token, RmcSource & source);


### PR DESCRIPTION
This fixes #21.

@generationmake can you please test and see if it fixes your problem?