### PR TITLE
Compile examples for an ESP32 board in the CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -19,6 +19,14 @@ jobs:
     env:
       SKETCHES_REPORTS_PATH: sketches-reports
 
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board:
+          - fqbn: "arduino:samd:mkrvidor4000"
+            platforms: |
+              - name: "arduino:samd"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,7 +34,8 @@ jobs:
       - name: Compile examples
         uses: arduino/compile-sketches@main
         with:
-          fqbn: arduino:samd:mkrvidor4000
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
           enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -27,9 +27,17 @@ jobs:
           - fqbn: "arduino:samd:mkrvidor4000"
             platforms: |
               - name: "arduino:samd"
+          - fqbn: "esp32:esp32:esp32"
+            platforms: |
+              - name: "esp32:esp32"
+                source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Install ESP32 platform dependencies
+        if: startsWith(matrix.board.fqbn, 'esp32:esp32')
+        run: pip3 install pyserial
 
       - name: Compile examples
         uses: arduino/compile-sketches@main

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -16,20 +16,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      SKETCHES_REPORTS_PATH: sketches-reports
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Compile examples
-        uses: arduino/actions/libraries/compile-examples@master
+        uses: arduino/compile-sketches@main
         with:
           fqbn: arduino:samd:mkrvidor4000
           size-report-sketch: NMEA-Basic
           enable-size-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save memory usage change report as artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v1
         with:
-          name: size-deltas-reports
-          path: size-deltas-reports
+          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -27,8 +27,7 @@ jobs:
         uses: arduino/compile-sketches@main
         with:
           fqbn: arduino:samd:mkrvidor4000
-          size-report-sketch: NMEA-Basic
-          enable-size-deltas-report: true
+          enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save memory usage change report as artifact


### PR DESCRIPTION
The `esp32:esp32` package is unique in that it doesn't provide all the necessary dependencies of the platform. For this
reason, an additional conditional step must be added to the workflow to install this dependency during the matrix job
for the ESP32 board.

Closes https://github.com/107-systems/107-Arduino-NMEA-Parser/issues/34