### PR TITLE
Changed rmc_isGxGGA to be called gga_isGxGGA for consistency

### DIFF
--- a/extras/test/src/test_gga.cpp
+++ b/extras/test/src/test_gga.cpp
@@ -17,47 +17,47 @@
  * TEST CODE
  **************************************************************************************/
 
-TEST_CASE ("Testing 'rmc_isGPGGA(...)' with valid and invalid GPGGA NMEA messages", "[rmc_isGPGGA-01]")
+TEST_CASE ("Testing 'gga_isGPGGA(...)' with valid and invalid GPGGA NMEA messages", "[gga_isGPGGA-01]")
 {
   WHEN ("a valid GPGGA NMEA message")
-    REQUIRE (nmea::util::rmc_isGPGGA("$GPGGA") == true);
+    REQUIRE (nmea::util::gga_isGPGGA("$GPGGA") == true);
   WHEN ("a invalid GPGGA NMEA message")
-    REQUIRE (nmea::util::rmc_isGPGGA("$GAGGA") == false);
+    REQUIRE (nmea::util::gga_isGPGGA("$GAGGA") == false);
 }
 
-TEST_CASE ("Testing 'rmc_isGLGGA(...)' with valid and invalid GLGGA NMEA messages", "[rmc_isGLGGA-01]")
+TEST_CASE ("Testing 'gga_isGLGGA(...)' with valid and invalid GLGGA NMEA messages", "[gga_isGLGGA-01]")
 {
   WHEN ("a valid GLGGA NMEA message")
-    REQUIRE (nmea::util::rmc_isGLGGA("$GLGGA") == true);
+    REQUIRE (nmea::util::gga_isGLGGA("$GLGGA") == true);
   WHEN ("a invalid GLGGA NMEA message")
-    REQUIRE (nmea::util::rmc_isGLGGA("$GAGGA") == false);
+    REQUIRE (nmea::util::gga_isGLGGA("$GAGGA") == false);
 }
 
-TEST_CASE ("Testing 'rmc_isGAGGA(...)' with valid and invalid GAGGA NMEA messages", "[rmc_isGAGGA-01]")
+TEST_CASE ("Testing 'gga_isGAGGA(...)' with valid and invalid GAGGA NMEA messages", "[gga_isGAGGA-01]")
 {
   WHEN ("a valid GAGGA NMEA message")
-    REQUIRE (nmea::util::rmc_isGAGGA("$GAGGA") == true);
+    REQUIRE (nmea::util::gga_isGAGGA("$GAGGA") == true);
   WHEN ("a invalid GAGGA NMEA message")
-    REQUIRE (nmea::util::rmc_isGAGGA("$GLGGA") == false);
+    REQUIRE (nmea::util::gga_isGAGGA("$GLGGA") == false);
 }
 
-TEST_CASE ("Testing 'rmc_isGNGGA(...)' with valid and invalid GNGGA NMEA messages", "[rmc_isGNGGA-01]")
+TEST_CASE ("Testing 'gga_isGNGGA(...)' with valid and invalid GNGGA NMEA messages", "[gga_isGNGGA-01]")
 {
   WHEN ("a valid GNGGA NMEA message")
-    REQUIRE (nmea::util::rmc_isGNGGA("$GNGGA") == true);
+    REQUIRE (nmea::util::gga_isGNGGA("$GNGGA") == true);
   WHEN ("a invalid GNGGA NMEA message")
-    REQUIRE (nmea::util::rmc_isGNGGA("$GAGGA") == false);
+    REQUIRE (nmea::util::gga_isGNGGA("$GAGGA") == false);
 }
 
-TEST_CASE ("Testing 'rmc_isGxGGA(...)' with valid and invalid G(P|L|A|N)GGA NMEA messages", "[rmc_isGxGGA-01]")
+TEST_CASE ("Testing 'gga_isGxGGA(...)' with valid and invalid G(P|L|A|N)GGA NMEA messages", "[gga_isGxGGA-01]")
 {
   WHEN ("a valid G(P|L|A|N)GGA NMEA message")
   {
-    REQUIRE (nmea::util::rmc_isGxGGA("$GPGGA") == true);
-    REQUIRE (nmea::util::rmc_isGxGGA("$GLGGA") == true);
-    REQUIRE (nmea::util::rmc_isGxGGA("$GAGGA") == true);
-    REQUIRE (nmea::util::rmc_isGxGGA("$GNGGA") == true);
+    REQUIRE (nmea::util::gga_isGxGGA("$GPGGA") == true);
+    REQUIRE (nmea::util::gga_isGxGGA("$GLGGA") == true);
+    REQUIRE (nmea::util::gga_isGxGGA("$GAGGA") == true);
+    REQUIRE (nmea::util::gga_isGxGGA("$GNGGA") == true);
   }
   WHEN ("a invalid G(P|L|A|N)GGA NMEA message")
-    REQUIRE (nmea::util::rmc_isGxGGA("$GIGGA") == false);
+    REQUIRE (nmea::util::gga_isGxGGA("$GIGGA") == false);
 }

--- a/src/ArduinoNmeaParser.cpp
+++ b/src/ArduinoNmeaParser.cpp
@@ -75,7 +75,7 @@ void ArduinoNmeaParser::encode(char const c)
 
   /* Parse the various NMEA messages. */
   if      (nmea::util::rmc_isGxRMC(_parser_buf)) parseGxRMC();
-  else if (nmea::util::rmc_isGxGGA(_parser_buf)) parseGxGGA();
+  else if (nmea::util::gga_isGxGGA(_parser_buf)) parseGxGGA();
 
   /* The NMEA message has been fully processed and all
    * values updates so its time to flush the parser

--- a/src/nmea/GxGGA.cpp
+++ b/src/nmea/GxGGA.cpp
@@ -79,13 +79,13 @@ void GxGGA::parse(char * gxgga, GgaData & data)
 
 GxGGA::ParserState GxGGA::handle_MessadeId(char const * token, GgaSource & source)
 {
-  if (util::rmc_isGPGGA(token))
+  if (util::gga_isGPGGA(token))
     source = GgaSource::GPS;
-  else if (util::rmc_isGLGGA(token))
+  else if (util::gga_isGLGGA(token))
     source = GgaSource::GLONASS;
-  else if (util::rmc_isGAGGA(token))
+  else if (util::gga_isGAGGA(token))
     source = GgaSource::Galileo;
-  else if (util::rmc_isGNGGA(token))
+  else if (util::gga_isGNGGA(token))
     source = GgaSource::GNSS;
 
   return ParserState::UTCPositionFix;

--- a/src/nmea/util/gga.cpp
+++ b/src/nmea/util/gga.cpp
@@ -28,29 +28,29 @@ namespace util
  * FUNCTION DEFINITION
  **************************************************************************************/
 
-bool rmc_isGPGGA(char const * nmea)
+bool gga_isGPGGA(char const * nmea)
 {
   return (strncmp(nmea, "$GPGGA", 6) == 0);
 }
 
-bool rmc_isGLGGA(char const * nmea)
+bool gga_isGLGGA(char const * nmea)
 {
   return (strncmp(nmea, "$GLGGA", 6) == 0);
 }
 
-bool rmc_isGAGGA(char const * nmea)
+bool gga_isGAGGA(char const * nmea)
 {
   return (strncmp(nmea, "$GAGGA", 6) == 0);
 }
 
-bool rmc_isGNGGA(char const * nmea)
+bool gga_isGNGGA(char const * nmea)
 {
   return (strncmp(nmea, "$GNGGA", 6) == 0);
 }
 
-bool rmc_isGxGGA(char const * nmea)
+bool gga_isGxGGA(char const * nmea)
 {
-  return (rmc_isGPGGA(nmea) || rmc_isGLGGA(nmea) || rmc_isGAGGA(nmea) || rmc_isGNGGA(nmea));
+  return (gga_isGPGGA(nmea) || gga_isGLGGA(nmea) || gga_isGAGGA(nmea) || gga_isGNGGA(nmea));
 }
 
 /**************************************************************************************

--- a/src/nmea/util/gga.h
+++ b/src/nmea/util/gga.h
@@ -28,11 +28,11 @@ namespace util
  * FUNCTION DECLARATION
  **************************************************************************************/
 
-bool  rmc_isGPGGA(char const * nmea);
-bool  rmc_isGLGGA(char const * nmea);
-bool  rmc_isGAGGA(char const * nmea);
-bool  rmc_isGNGGA(char const * nmea);
-bool  rmc_isGxGGA(char const * nmea);
+bool  gga_isGPGGA(char const * nmea);
+bool  gga_isGLGGA(char const * nmea);
+bool  gga_isGAGGA(char const * nmea);
+bool  gga_isGNGGA(char const * nmea);
+bool  gga_isGxGGA(char const * nmea);
 
 /**************************************************************************************
  * NAMESPACE


### PR DESCRIPTION
Hi,

I've gone through all the code of this library and changed the rmc_isGxGGA functions to be called gga_isGxGGA. The RMC functions rmc_isGxRMC are untouched. I've just changed the prefix on the GGA functions to be gga rather than rmc, since they have nothing to do with RMC strings. For the sake of consistency and readability, I believe the GGA functions should be called gga. I suspect the fact that they start with rmc is a matter of old copy-pasted code sticking around and renaming them would aid the codebase in being more self consistent and comprehensible.

I realize this would make new versions fail to be backward compatible with old code which may use these rmc_isGxGGA functions. However, it seems unlikely that many users would be using these, since primarily the identification of commands is handled within the library itself, and given that I've already changed all the calls within the library to use the new "gga_" versions, this incompatibility should be minor.

Thank you for considering this pull request. If approved, I hope to also add other NMEA strings to this library, including GPGSV.