### PR TITLE
Fixed typo in several places, Messade -> Message

### DIFF
--- a/src/nmea/GxGGA.cpp
+++ b/src/nmea/GxGGA.cpp
@@ -34,7 +34,7 @@ namespace nmea
 
 void GxGGA::parse(char * gxgga, GgaData & data)
 {
-  ParserState state = ParserState::MessadeId;
+  ParserState state = ParserState::MessageId;
 
   /* Replace the '*' sign denoting the start of the checksum
    * with a ',' in order to be able to tokenize all elements
@@ -50,7 +50,7 @@ void GxGGA::parse(char * gxgga, GgaData & data)
 
     switch(state)
     {
-    case ParserState::MessadeId:                     next_state = handle_MessadeId                    (token, data.source);             break;
+    case ParserState::MessageId:                     next_state = handle_MessageId                    (token, data.source);             break;
     case ParserState::UTCPositionFix:                next_state = handle_UTCPositionFix               (token, data.time_utc);           break;
     case ParserState::LatitudeVal:                   next_state = handle_LatitudeVal                  (token, data.latitude);           break;
     case ParserState::LatitudeNS:                    next_state = handle_LatitudeNS                   (token, data.latitude);           break;
@@ -77,7 +77,7 @@ void GxGGA::parse(char * gxgga, GgaData & data)
  * PRIVATE MEMBER FUNCTIONS
  **************************************************************************************/
 
-GxGGA::ParserState GxGGA::handle_MessadeId(char const * token, GgaSource & source)
+GxGGA::ParserState GxGGA::handle_MessageId(char const * token, GgaSource & source)
 {
   if (util::gga_isGPGGA(token))
     source = GgaSource::GPS;

--- a/src/nmea/GxGGA.h
+++ b/src/nmea/GxGGA.h
@@ -41,7 +41,7 @@ private:
 
   enum class ParserState : int
   {
-    MessadeId,
+    MessageId,
     UTCPositionFix,
     LatitudeVal,
     LatitudeNS,
@@ -60,7 +60,7 @@ private:
     Done
   };
 
-  static ParserState handle_MessadeId                    (char const * token, GgaSource & source);
+  static ParserState handle_MessageId                    (char const * token, GgaSource & source);
   static ParserState handle_UTCPositionFix               (char const * token, Time & time_utc);
   static ParserState handle_LatitudeVal                  (char const * token, float & latitude);
   static ParserState handle_LatitudeNS                   (char const * token, float & latitude);

--- a/src/nmea/GxRMC.cpp
+++ b/src/nmea/GxRMC.cpp
@@ -40,7 +40,7 @@ constexpr float kts_to_m_per_s(float const v) { return (v / 1.9438444924574f); }
 
 void GxRMC::parse(char * gxrmc, RmcData & data)
 {
-  ParserState state = ParserState::MessadeId;
+  ParserState state = ParserState::MessageId;
 
   /* Replace the '*' sign denoting the start of the checksum
    * with a ',' in order to be able to tokenize all elements
@@ -56,7 +56,7 @@ void GxRMC::parse(char * gxrmc, RmcData & data)
 
     switch(state)
     {
-    case ParserState::MessadeId:                  next_state = handle_MessadeId                (token, data.source);             break;
+    case ParserState::MessageId:                  next_state = handle_MessageId                (token, data.source);             break;
     case ParserState::UTCPositionFix:             next_state = handle_UTCPositionFix           (token, data.time_utc);           break;
     case ParserState::Status:                     next_state = handle_Status                   (token, data.is_valid);           break;
     case ParserState::LatitudeVal:                next_state = handle_LatitudeVal              (token, data.latitude);           break;
@@ -80,7 +80,7 @@ void GxRMC::parse(char * gxrmc, RmcData & data)
  * PRIVATE MEMBER FUNCTIONS
  **************************************************************************************/
 
-GxRMC::ParserState GxRMC::handle_MessadeId(char const * token, RmcSource & source)
+GxRMC::ParserState GxRMC::handle_MessageId(char const * token, RmcSource & source)
 {
   if (util::rmc_isGPRMC(token))
     source = RmcSource::GPS;

--- a/src/nmea/GxRMC.h
+++ b/src/nmea/GxRMC.h
@@ -41,7 +41,7 @@ private:
 
   enum class ParserState : int
   {
-    MessadeId,
+    MessageId,
     UTCPositionFix,
     Status,
     LatitudeVal,
@@ -57,7 +57,7 @@ private:
     Done
   };
 
-  static ParserState handle_MessadeId                (char const * token, RmcSource & source);
+  static ParserState handle_MessageId                (char const * token, RmcSource & source);
   static ParserState handle_UTCPositionFix           (char const * token, Time & time_utc);
   static ParserState handle_Status                   (char const * token, bool & is_valid);
   static ParserState handle_LatitudeVal              (char const * token, float & latitude);


### PR DESCRIPTION
Hi!

I'm now working on adding support for more NMEA strings (so be on the lookout for more pull requests! :smile: )

While digging through the existing strings (RMC and GGA) I found that there were a few places referencing incoming messages, but they were called "messade". I believe this is a typo; this pull request has gone through and changed all instances to "Message".