### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4 (#63)"

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
           coverage-data-path: ${{ env.COVERAGE_DATA_PATH }}
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           file: ${{ env.COVERAGE_DATA_PATH }}
           fail_ci_if_error: true


### PR DESCRIPTION
This reverts commit 2c2906236bdabd193c48cf9f8fa7721f8489ee57.

The bump originated from an automated PR from Dependabot triggered by an accidental `v4` tag push in the codecov/codecov-action repository: https://github.com/codecov/codecov-action/issues/1089

The tag has since been removed due to the v4 major version series of the action still being in the beta development phase. That removal caused subsequent runs of the workflow to fail:

https://github.com/107-systems/107-Arduino-NMEA-Parser/actions/runs/6194476893/job/16817534063#step:1:35

```text
Error: Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`
```

So the action ref must be reverted back to `v3`. It can be bumped back to the `v4` major version ref following the production 4.0.0 release in the action's repo.

---

Note: The [Codecov upload token](https://docs.codecov.com/docs/frequently-asked-questions#where-is-the-repository-upload-token-found) is [no longer optional](https://github.com/codecov/codecov-action/tree/main#v4-beta-release) in v4 of the action, so it will be necessary to also adjust the workflow to provide the token to the action at the same time as the bump. Doing so is a good idea anyway because, although supported in v3, the lack of a token was causing periodic [spurious coverage data upload failures](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954). That was done already in the Arduino CLI repo (https://github.com/arduino/arduino-cli/pull/2129) and the approach used there has passed the test of time with flying colors.
